### PR TITLE
Fix build

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2364,7 +2364,7 @@ void str_utf8_trim_right(char* param)
 	}
 }
 
-static int str_utf8_isstart(char c)
+int str_utf8_isstart(char c)
 {
 	if((c&0xC0) == 0x80) /* 10xxxxxx */
 		return 0;


### PR DESCRIPTION
```
[  2%] Building C object CMakeFiles/engine-shared.dir/src/base/system.c.o
/home/chiller/Desktop/git/ddnet7/src/base/system.c:2367:12: error: static declaration of ‘str_utf8_isstart’ follows non-static declaration
 static int str_utf8_isstart(char c)
            ^~~~~~~~~~~~~~~~
In file included from /home/chiller/Desktop/git/ddnet7/src/base/system.c:10:
/home/chiller/Desktop/git/ddnet7/src/base/system.h:1514:5: note: previous declaration of ‘str_utf8_isstart’ was here
 int str_utf8_isstart(char c);
     ^~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/engine-shared.dir/build.make:506: CMakeFiles/engine-shared.dir/src/base/system.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:592: CMakeFiles/engine-shared.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```