### PR TITLE
Add protocol extension with UUIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ map_version*
 mastersrv*
 packetgen*
 testrunner
+uuid*
 versionsrv*
 
 # IDE project files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1193,6 +1193,7 @@ set_src(ENGINE_INTERFACE GLOB src/engine
   sound.h
   storage.h
   textrender.h
+  uuid.h
 )
 set_src(ENGINE_SHARED GLOB src/engine/shared
   compression.cpp
@@ -1213,6 +1214,7 @@ set_src(ENGINE_SHARED GLOB src/engine/shared
   fifo.h
   filecollection.cpp
   filecollection.h
+  global_uuid_manager.cpp
   huffman.cpp
   huffman.h
   jobs.cpp
@@ -1240,11 +1242,16 @@ set_src(ENGINE_SHARED GLOB src/engine/shared
   packer.cpp
   packer.h
   protocol.h
+  protocol_ex.cpp
+  protocol_ex.h
+  protocol_ex_msgs.h
   ringbuffer.cpp
   ringbuffer.h
   snapshot.cpp
   snapshot.h
   storage.cpp
+  uuid_manager.cpp
+  uuid_manager.h
 )
 set(ENGINE_GENERATED_SHARED src/generated/protocol.cpp src/generated/protocol.h)
 set_src(GAME_SHARED GLOB src/game
@@ -1587,6 +1594,7 @@ set_src(TOOLS GLOB src/tools
   map_resave.cpp
   map_version.cpp
   packetgen.cpp
+  uuid.cpp
 )
 foreach(ABS_T ${TOOLS})
   file(RELATIVE_PATH T "${PROJECT_SOURCE_DIR}/src/tools/" ${ABS_T})
@@ -1615,6 +1623,7 @@ add_custom_target(everything DEPENDS ${TARGETS_OWN})
 
 if(GTEST_FOUND OR DOWNLOAD_GTEST)
   set_src(TESTS GLOB src/test
+    ex.cpp
     fs.cpp
     git_revision.cpp
     hash.cpp

--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -6,8 +6,7 @@ import network
 def create_enum_table(names, num):
 	lines = []
 	lines += ["enum", "{"]
-	lines += ["\t%s=0,"%names[0]]
-	for name in names[1:]:
+	for name in names:
 		lines += ["\t%s,"%name]
 	lines += ["\t%s" % num, "};"]
 	return lines
@@ -109,9 +108,17 @@ if gen_network_header:
 		for l in create_flags_table(["%s_%s" % (e.name, v) for v in e.values]): print(l)
 		print("")
 
-	for l in create_enum_table(["NETOBJ_INVALID"]+[o.enum_name for o in network.Objects], "NUM_NETOBJTYPES"): print(l)
+	non_extended = [o for o in network.Objects if o.ex is None]
+	extended = [o for o in network.Objects if o.ex is not None]
+	for l in create_enum_table(["NETOBJTYPE_EX"]+[o.enum_name for o in non_extended], "NUM_NETOBJTYPES"): print(l)
+	for l in create_enum_table(["__NETOBJTYPE_UUID_HELPER=OFFSET_GAME_UUID-1"]+[o.enum_name for o in extended], "OFFSET_NETMSGTYPE_UUID"): print(l)
 	print("")
-	for l in create_enum_table(["NETMSG_INVALID"]+[o.enum_name for o in network.Messages], "NUM_NETMSGTYPES"): print(l)
+
+	non_extended = [o for o in network.Messages if o.ex is None]
+	extended = [o for o in network.Messages if o.ex is not None]
+	for l in create_enum_table(["NETMSGTYPE_EX"]+[o.enum_name for o in non_extended], "NUM_NETMSGTYPES"): print(l)
+	print("")
+	for l in create_enum_table(["__NETMSGTYPE_UUID_HELPER=OFFSET_NETMSGTYPE_UUID-1"]+[o.enum_name for o in extended], "END_NETMSGTYPE_UUID"): print(l)
 	print("")
 
 	for item in network.Objects + network.Messages:
@@ -198,19 +205,20 @@ if gen_network_source:
 
 	lines += ["const char *CNetObjHandler::ms_apObjNames[] = {"]
 	lines += ['\t"invalid",']
-	lines += ['\t"%s",' % o.name for o in network.Objects]
+	lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is None]
 	lines += ['\t""', "};", ""]
 
 	lines += ["int CNetObjHandler::ms_aObjSizes[] = {"]
 	lines += ['\t0,']
-	lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects]
+	lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is None]
 	lines += ['\t0', "};", ""]
 
 
 	lines += ['const char *CNetObjHandler::ms_apMsgNames[] = {']
 	lines += ['\t"invalid",']
 	for msg in network.Messages:
-		lines += ['\t"%s",' % msg.name]
+		if msg.ex is None:
+			lines += ['\t"%s",' % msg.name]
 	lines += ['\t""']
 	lines += ['};']
 	lines += ['']
@@ -267,6 +275,10 @@ if gen_network_source:
 	lines += ['{']
 	lines += ['\tswitch(Type)']
 	lines += ['\t{']
+	lines += ['\tcase NETOBJTYPE_EX:']
+	lines += ['\t{']
+	lines += ['\t\treturn 0;']
+	lines += ['\t}']
 
 	for item in network.Objects:
 		for line in item.emit_validate():
@@ -329,6 +341,14 @@ if gen_network_source:
 	lines += ['};']
 	lines += ['']
 
+
+	lines += ['void RegisterGameUuids(CUuidManager *pManager)']
+	lines += ['{']
+
+	for item in network.Objects + network.Messages:
+		if item.ex is not None:
+			lines += ['\tpManager->RegisterName(%s, "%s");' % (item.enum_name, item.ex)]
+	lines += ['}']
 
 	for l in lines:
 		print(l)

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -210,7 +210,7 @@ class Flags:
 		self.values = values
 
 class NetObject:
-	def __init__(self, name, variables):
+	def __init__(self, name, variables, ex=None, fixup=True):
 		l = name.split(":")
 		self.name = l[0]
 		self.base = ""
@@ -220,6 +220,10 @@ class NetObject:
 		self.struct_name = "CNetObj_%s" % self.name
 		self.enum_name = "NETOBJTYPE_%s" % self.name.upper()
 		self.variables = variables
+		if fixup and ex != None:
+			ex = "object-{}".format(ex)
+		self.ex = ex
+
 	def emit_declaration(self):
 		if self.base:
 			lines = ["struct %s : public %s"%(self.struct_name,self.base_struct_name), "{"]
@@ -233,24 +237,25 @@ class NetObject:
 		lines = ["case %s:" % self.enum_name]
 		lines += ["{"]
 		lines += ["\t%s *pObj = (%s *)pData;"%(self.struct_name, self.struct_name)]
-		lines += ["\tif(sizeof(*pObj) != Size) return -1;"]
+		lines += ["\tif((int)sizeof(*pObj) > Size) return -1;"]
 		for v in self.variables:
 			lines += ["\t"+line for line in v.emit_validate()]
 		lines += ["\treturn 0;"]
 		lines += ["}"]
 		return lines
 
-
 class NetEvent(NetObject):
-	def __init__(self, name, variables):
-		NetObject.__init__(self, name, variables)
+	def __init__(self, name, variables, ex=None):
+		NetObject.__init__(self, name, variables, ex=ex)
 		self.base_struct_name = "CNetEvent_%s" % self.base
 		self.struct_name = "CNetEvent_%s" % self.name
 		self.enum_name = "NETEVENTTYPE_%s" % self.name.upper()
 
 class NetMessage(NetObject):
-	def __init__(self, name, variables):
-		NetObject.__init__(self, name, variables)
+	def __init__(self, name, variables, ex=None):
+		if ex != None:
+			ex = "message-{}".format(ex)
+		NetObject.__init__(self, name, variables, ex=ex, fixup=False)
 		self.base_struct_name = "CNetMsg_%s" % self.base
 		self.struct_name = "CNetMsg_%s" % self.name
 		self.enum_name = "NETMSGTYPE_%s" % self.name.upper()
@@ -282,6 +287,18 @@ class NetMessage(NetObject):
 		lines = NetObject.emit_declaration(self)
 		lines = lines[:-1] + extra + lines[-1:]
 		return lines
+
+class NetObjectEx(NetObject):
+	def __init__(self, name, ex, variables):
+		NetObject.__init__(self, name, variables, ex=ex)
+
+class NetEventEx(NetEvent):
+	def __init__(self, name, ex, variables):
+		NetEvent.__init__(self, name, variables, ex=ex)
+
+class NetMessageEx(NetMessage):
+	def __init__(self, name, ex, variables):
+		NetMessage.__init__(self, name, variables, ex=ex)
 
 
 class NetVariable:

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -24,6 +24,7 @@ GameMsgIDs = Enum("GAMEMSG", ["TEAM_SWAP", "SPEC_INVALIDID", "TEAM_SHUFFLE", "TE
 RawHeader = '''
 
 #include <engine/message.h>
+#include <engine/shared/protocol_ex.h>
 
 enum
 {
@@ -223,6 +224,10 @@ Objects = [
 		NetArray(NetIntAny("m_aTuneParams"), 32),
 	]),
 
+	NetObjectEx("MyOwnObject", "my-own-object@heinrich5991.de", [
+		NetIntAny("m_Test"),
+	]),
+
 	## Events
 
 	NetEvent("Common", [
@@ -249,6 +254,10 @@ Objects = [
 		NetIntRange("m_HealthAmount", 0, 9),
 		NetIntRange("m_ArmorAmount", 0, 9),
 		NetBool("m_Self"),
+	]),
+
+	NetObjectEx("MyOwnEvent", "my-own-event@heinrich5991.de", [
+		NetIntAny("m_Test"),
 	]),
 ]
 
@@ -433,5 +442,10 @@ Messages = [
 		NetArray(NetStringStrict("m_apSkinPartNames"), 6),
 		NetArray(NetBool("m_aUseCustomColors"), 6),
 		NetArray(NetIntAny("m_aSkinPartColors"), 6),
+	]),
+	# Can't add any NetMessages here!
+
+	NetMessageEx("Sv_MyOwnMessage", "my-own-message@heinrich5991.de", [
+		NetIntAny("m_Test"),
 	]),
 ]

--- a/src/engine/message.h
+++ b/src/engine/message.h
@@ -4,6 +4,7 @@
 #define ENGINE_MESSAGE_H
 
 #include <engine/shared/packer.h>
+#include <engine/shared/uuid_manager.h>
 
 class CMsgPacker : public CPacker
 {
@@ -11,7 +12,13 @@ public:
 	CMsgPacker(int Type, bool System=false)
 	{
 		Reset();
-		AddInt((Type<<1)|(System?1:0));
+		// NETMSG_EX, NETMSGTYPE_EX for UUID messages
+		int NetType = Type < OFFSET_UUID ? Type : 0;
+		AddInt((NetType<<1)|(System?1:0));
+		if(Type >= OFFSET_UUID)
+		{
+			g_UuidManager.PackUuid(Type, this);
+		}
 	}
 };
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -23,6 +23,7 @@
 #include <engine/shared/network.h>
 #include <engine/shared/packer.h>
 #include <engine/shared/protocol.h>
+#include <engine/shared/protocol_ex.h>
 #include <engine/shared/snapshot.h>
 #include <engine/shared/fifo.h>
 
@@ -872,14 +873,22 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 	int ClientID = pPacket->m_ClientID;
 	CUnpacker Unpacker;
 	Unpacker.Reset(pPacket->m_pData, pPacket->m_DataSize);
+	CMsgPacker Packer(NETMSG_EX);
 
 	// unpack msgid and system flag
-	int Msg = Unpacker.GetInt();
-	int Sys = Msg&1;
-	Msg >>= 1;
+	int Msg;
+	bool Sys;
+	CUuid Uuid;
 
-	if(Unpacker.Error())
+	int Result = UnpackMessageID(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
+	if(Result == UNPACKMESSAGE_ERROR)
+	{
 		return;
+	}
+	else if(Result == UNPACKMESSAGE_ANSWER)
+	{
+		SendMsg(&Packer, MSGFLAG_VITAL, ClientID);
+	}
 
 	if(Sys)
 	{
@@ -1338,6 +1347,11 @@ void CServer::InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterS
 
 int CServer::Run()
 {
+	if(g_Config.m_Debug)
+	{
+		g_UuidManager.DebugDump();
+	}
+
 	//
 	m_PrintCBIndex = Console()->RegisterPrintCallback(g_Config.m_ConsoleOutputLevel, SendRconLineAuthed, this);
 
@@ -1815,8 +1829,11 @@ void CServer::SnapFreeID(int ID)
 
 void *CServer::SnapNewItem(int Type, int ID, int Size)
 {
-	dbg_assert(Type >= 0 && Type <=0xffff, "incorrect type");
-	dbg_assert(ID >= 0 && ID <=0xffff, "incorrect id");
+	if(!(Type >= 0 && Type <= 0xffff))
+	{
+		g_UuidManager.GetUuid(Type);
+	}
+	dbg_assert(ID >= 0 && ID <= 0xffff, "incorrect id");
 	return ID < 0 ? 0 : m_SnapshotBuilder.NewItem(Type, ID, Size);
 }
 

--- a/src/engine/shared/global_uuid_manager.cpp
+++ b/src/engine/shared/global_uuid_manager.cpp
@@ -1,0 +1,14 @@
+#include "protocol_ex.h"
+#include "uuid_manager.h"
+
+#include <engine/uuid.h>
+
+static CUuidManager CreateGlobalUuidManager()
+{
+	CUuidManager Manager;
+	RegisterUuids(&Manager);
+	RegisterGameUuids(&Manager);
+	return Manager;
+}
+
+CUuidManager g_UuidManager = CreateGlobalUuidManager();

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -30,7 +30,7 @@
 
 enum
 {
-	NETMSG_NULL=0,
+	NETMSG_EX=0,
 
 	// the first thing sent by the client
 	// contains the version info for the client
@@ -73,6 +73,8 @@ enum
 
 	NETMSG_MAPLIST_ENTRY_ADD,// todo 0.8: move up
 	NETMSG_MAPLIST_ENTRY_REM,
+
+	NUM_NETMSGS,
 };
 
 // this should be revised

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -1,0 +1,102 @@
+#include "protocol_ex.h"
+
+#include "config.h"
+#include "protocol.h"
+#include "uuid_manager.h"
+
+#include <new>
+
+void RegisterUuids(class CUuidManager *pManager)
+{
+	#define UUID(id, name) pManager->RegisterName(id, "system-message-" name);
+	#include "protocol_ex_msgs.h"
+	#undef UUID
+}
+
+int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker)
+{
+	*pID = 0;
+	*pSys = false;
+	mem_zero(pUuid, sizeof(*pUuid));
+
+	int MsgID = pUnpacker->GetInt();
+
+	if(pUnpacker->Error())
+	{
+		return UNPACKMESSAGE_ERROR;
+	}
+
+	*pID = MsgID >> 1;
+	*pSys = MsgID & 1;
+
+	if(*pID < 0 || *pID >= OFFSET_UUID)
+	{
+		return UNPACKMESSAGE_ERROR;
+	}
+
+	if(*pID != 0) // NETMSG_EX, NETMSGTYPE_EX
+	{
+		return UNPACKMESSAGE_OK;
+	}
+
+	*pID = g_UuidManager.UnpackUuid(pUnpacker, pUuid);
+
+	if(*pID == UUID_INVALID || *pID == UUID_UNKNOWN)
+	{
+		return UNPACKMESSAGE_ERROR;
+	}
+
+	if(*pSys)
+	{
+		switch(*pID)
+		{
+		case NETMSG_WHATIS:
+			{
+				CUuid Uuid2;
+				int ID2 = g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
+				if(ID2 == UUID_INVALID)
+				{
+					break;
+				}
+				if(ID2 == UUID_UNKNOWN)
+				{
+					new (pPacker) CMsgPacker(NETMSG_IDONTKNOW, true);
+					pPacker->AddRaw(&Uuid2, sizeof(Uuid2));
+				}
+				else
+				{
+					new (pPacker) CMsgPacker(NETMSG_ITIS, true);
+					pPacker->AddRaw(&Uuid2, sizeof(Uuid2));
+					pPacker->AddString(g_UuidManager.GetName(ID2), 0);
+				}
+				return UNPACKMESSAGE_ANSWER;
+			}
+		case NETMSG_IDONTKNOW:
+			if(g_Config.m_Debug)
+			{
+				CUuid Uuid2;
+				g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
+				if(pUnpacker->Error())
+					break;
+				char aBuf[UUID_MAXSTRSIZE];
+				FormatUuid(Uuid2, aBuf, sizeof(aBuf));
+				dbg_msg("uuid", "peer: unknown %s", aBuf);
+			}
+			break;
+		case NETMSG_ITIS:
+			if(g_Config.m_Debug)
+			{
+				CUuid Uuid2;
+				g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
+				const char *pName = pUnpacker->GetString(CUnpacker::SANITIZE_CC);
+				if(pUnpacker->Error())
+					break;
+				char aBuf[UUID_MAXSTRSIZE];
+				FormatUuid(Uuid2, aBuf, sizeof(aBuf));
+				dbg_msg("uuid", "peer: %s %s", aBuf, pName);
+			}
+			break;
+		}
+	}
+	return UNPACKMESSAGE_OK;
+}

--- a/src/engine/shared/protocol_ex.h
+++ b/src/engine/shared/protocol_ex.h
@@ -1,0 +1,28 @@
+#ifndef ENGINE_SHARED_PROTOCOL_EX_H
+#define ENGINE_SHARED_PROTOCOL_EX_H
+
+#include <engine/message.h>
+
+enum
+{
+	NETMSG_EX_INVALID=UUID_INVALID,
+	NETMSG_EX_UNKNOWN=UUID_UNKNOWN,
+
+	OFFSET_NETMSG_UUID=OFFSET_UUID,
+
+	__NETMSG_UUID_HELPER=OFFSET_NETMSG_UUID-1,
+	#define UUID(id, name) id,
+	#include "protocol_ex_msgs.h"
+	#undef UUID
+	OFFSET_GAME_UUID,
+
+	UNPACKMESSAGE_ERROR=0,
+	UNPACKMESSAGE_OK,
+	UNPACKMESSAGE_ANSWER,
+};
+
+void RegisterUuids(class CUuidManager *pManager);
+
+int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker);
+
+#endif // ENGINE_SHARED_PROTOCOL_EX_H

--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -1,0 +1,23 @@
+// UUID(name_in_code, name)
+//
+// When adding your own extended net messages, choose the name (third
+// parameter) as `<name>@<domain>` where `<name>` is a name you can choose
+// freely and `<domain>` is a domain you own. If you don't own a domain, try
+// choosing a string that is not a domain and uniquely identifies you, e.g. use
+// the name of the client/server you develop.
+//
+// Example:
+//
+// 1) `i-unfreeze-you@ddnet.tw`
+// 2) `creeper@minetee`
+//
+// The first example applies if you own the `ddnet.tw` domain, that is, if you
+// are adding this message on behalf of the DDNet team.
+//
+// The second example shows how you could add a message if you don't own a
+// domain, but need a message for your minetee client/server.
+
+UUID(NETMSG_WHATIS,         "what-is@ddnet.tw")
+UUID(NETMSG_ITIS,           "it-is@ddnet.tw")
+UUID(NETMSG_IDONTKNOW,      "i-dont-know@ddnet.tw")
+UUID(NETMSG_MYOWNMESSAGE,   "my-own-message@heinrich5991.de")

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -37,6 +37,8 @@ class CSnapshot
 public:
 	enum
 	{
+		OFFSET_UUID_TYPE=0x4000,
+		MAX_TYPE=0x7fff,
 		MAX_PARTS	= 64,
 		MAX_SIZE	= MAX_PARTS*1024
 	};
@@ -45,7 +47,9 @@ public:
 	int NumItems() const { return m_NumItems; }
 	const CSnapshotItem *GetItem(int Index) const;
 	int GetItemSize(int Index) const;
-	int GetItemIndex(int Key) const;
+	int GetItemIndex(int Type, int ID) const;
+	int GetItemType(int Index) const;
+
 	void InvalidateItem(int Index);
 
 	int Crc() const;
@@ -122,7 +126,8 @@ class CSnapshotBuilder
 {
 	enum
 	{
-		MAX_ITEMS = 1024
+		MAX_ITEMS = 1024,
+		MAX_EXTENDED_ITEM_TYPES = 64,
 	};
 
 	char m_aData[CSnapshot::MAX_SIZE];
@@ -131,7 +136,15 @@ class CSnapshotBuilder
 	int m_aOffsets[MAX_ITEMS];
 	int m_NumItems;
 
+	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];
+	int m_NumExtendedItemTypes;
+
+	void AddExtendedItemType(int Index);
+	int GetExtendedItemTypeIndex(int TypeID);
+
 public:
+	CSnapshotBuilder();
+
 	void Init();
 	void Init(const CSnapshot *pSnapshot);
 

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -1,0 +1,131 @@
+#include "uuid_manager.h"
+
+#include <engine/external/md5/md5.h>
+#include <engine/shared/packer.h>
+
+#include <stdio.h>
+
+static const CUuid TEEWORLDS_NAMESPACE = {{
+	// "e05ddaaa-c4e6-4cfb-b642-5d48e80c0029"
+	0xe0, 0x5d, 0xda, 0xaa, 0xc4, 0xe6, 0x4c, 0xfb,
+	0xb6, 0x42, 0x5d, 0x48, 0xe8, 0x0c, 0x00, 0x29
+}};
+
+CUuid CalculateUuid(const char *pName)
+{
+	md5_state_t Md5;
+	md5_byte_t aDigest[16];
+	md5_init(&Md5);
+
+	md5_append(&Md5, TEEWORLDS_NAMESPACE.m_aData, sizeof(TEEWORLDS_NAMESPACE.m_aData));
+	// Without terminating NUL.
+	md5_append(&Md5, (const unsigned char *)pName, str_length(pName));
+	md5_finish(&Md5, aDigest);
+
+	CUuid Result;
+	for(unsigned i = 0; i < sizeof(Result.m_aData); i++)
+	{
+		Result.m_aData[i] = aDigest[i];
+	}
+
+	Result.m_aData[6] &= 0x0f;
+	Result.m_aData[6] |= 0x30;
+	Result.m_aData[8] &= 0x3f;
+	Result.m_aData[8] |= 0x80;
+	return Result;
+}
+
+void FormatUuid(CUuid Uuid, char *pBuffer, unsigned BufferLength)
+{
+	unsigned char *p = Uuid.m_aData;
+	str_format(pBuffer, BufferLength,
+		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
+		p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
+}
+
+bool CUuid::operator==(const CUuid& Other)
+{
+	return mem_comp(this, &Other, sizeof(*this)) == 0;
+}
+
+bool CUuid::operator!=(const CUuid& Other)
+{
+	return !(*this == Other);
+}
+
+static int GetIndex(int ID)
+{
+	return ID - OFFSET_UUID;
+}
+
+static int GetID(int Index)
+{
+	return Index + OFFSET_UUID;
+}
+
+void CUuidManager::RegisterName(int ID, const char *pName)
+{
+	dbg_assert(GetIndex(ID) == m_aNames.size(), "names must be registered with increasing ID");
+	CName Name;
+	Name.m_pName = pName;
+	Name.m_Uuid = CalculateUuid(pName);
+	dbg_assert(LookupUuid(Name.m_Uuid) == -1, "duplicate uuid");
+
+	m_aNames.add(Name);
+}
+
+CUuid CUuidManager::GetUuid(int ID) const
+{
+	return m_aNames[GetIndex(ID)].m_Uuid;
+}
+
+const char *CUuidManager::GetName(int ID) const
+{
+	return m_aNames[GetIndex(ID)].m_pName;
+}
+
+int CUuidManager::LookupUuid(CUuid Uuid) const
+{
+	for(int i = 0; i < m_aNames.size(); i++)
+	{
+		if(Uuid == m_aNames[i].m_Uuid)
+		{
+			return GetID(i);
+		}
+	}
+	return UUID_UNKNOWN;
+}
+
+int CUuidManager::UnpackUuid(CUnpacker *pUnpacker) const
+{
+	CUuid Temp;
+	return UnpackUuid(pUnpacker, &Temp);
+}
+
+int CUuidManager::UnpackUuid(CUnpacker *pUnpacker, CUuid *pOut) const
+{
+	const CUuid *pUuid = (const CUuid *)pUnpacker->GetRaw(sizeof(*pUuid));
+	if(pUuid == NULL)
+	{
+		return UUID_INVALID;
+	}
+	*pOut = *pUuid;
+	return LookupUuid(*pUuid);
+}
+
+void CUuidManager::PackUuid(int ID, CPacker *pPacker) const
+{
+	CUuid Uuid = GetUuid(ID);
+	pPacker->AddRaw(&Uuid, sizeof(Uuid));
+}
+
+void CUuidManager::DebugDump() const
+{
+	for(int i = 0; i < m_aNames.size(); i++)
+	{
+		char aBuf[UUID_MAXSTRSIZE];
+		FormatUuid(m_aNames[i].m_Uuid, aBuf, sizeof(aBuf));
+		dbg_msg("uuid", "%s %s", aBuf, m_aNames[i].m_pName);
+	}
+}

--- a/src/engine/shared/uuid_manager.h
+++ b/src/engine/shared/uuid_manager.h
@@ -1,0 +1,54 @@
+#ifndef ENGINE_SHARED_UUID_MANAGER_H
+#define ENGINE_SHARED_UUID_MANAGER_H
+
+#include <base/tl/array.h>
+
+enum
+{
+	UUID_MAXSTRSIZE = 37, // 12345678-0123-5678-0123-567890123456
+
+	UUID_INVALID=-2,
+	UUID_UNKNOWN=-1,
+
+	OFFSET_UUID=1<<16,
+};
+
+struct CUuid
+{
+	unsigned char m_aData[16];
+
+	bool operator==(const CUuid &Other);
+	bool operator!=(const CUuid &Other);
+};
+
+CUuid CalculateUuid(const char *pName);
+void FormatUuid(CUuid Uuid, char *pBuffer, unsigned BufferLength);
+
+struct CName
+{
+	CUuid m_Uuid;
+	const char *m_pName;
+};
+
+class CPacker;
+class CUnpacker;
+
+class CUuidManager
+{
+	array<CName> m_aNames;
+public:
+	void RegisterName(int ID, const char *pName);
+	CUuid GetUuid(int ID) const;
+	const char *GetName(int ID) const;
+	int LookupUuid(CUuid Uuid) const;
+
+	int UnpackUuid(CUnpacker *pUnpacker) const;
+	int UnpackUuid(CUnpacker *pUnpacker, CUuid *pOut) const;
+	void PackUuid(int ID, CPacker *pPacker) const;
+
+	void DebugDump() const;
+};
+
+extern CUuidManager g_UuidManager;
+
+#endif // ENGINE_SHARED_UUID_MANAGER_H

--- a/src/engine/uuid.h
+++ b/src/engine/uuid.h
@@ -1,0 +1,4 @@
+#ifndef ENGINE_UUID_H
+#define ENGINE_UUID_H
+void RegisterGameUuids(CUuidManager *pManager);
+#endif // ENGINE_UUID_H

--- a/src/test/ex.cpp
+++ b/src/test/ex.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#include <engine/message.h>
+#include <engine/shared/protocol_ex.h>
+#include <engine/shared/snapshot.h>
+#include <generated/protocol.h>
+
+static void TestMessage(bool WantedSys, int WantedID, const void *pData, int Size, CUnpacker *pUnpacker)
+{
+	pUnpacker->Reset(pData, Size);
+
+	int ID;
+	bool Sys;
+	CUuid Uuid;
+	CMsgPacker Answer(0);
+	EXPECT_EQ(UnpackMessageID(&ID, &Sys, &Uuid, pUnpacker, &Answer), (int)UNPACKMESSAGE_OK);
+	EXPECT_EQ(ID, WantedID);
+	EXPECT_EQ(Sys, WantedSys);
+}
+
+TEST(Ex, MessageSys)
+{
+	CMsgPacker Packer(NETMSG_MYOWNMESSAGE, true);
+	Packer.AddString("canary", 0);
+	CUnpacker Unpacker;
+	TestMessage(true, NETMSG_MYOWNMESSAGE, Packer.Data(), Packer.Size(), &Unpacker);
+	EXPECT_STREQ(Unpacker.GetString(), "canary");
+}
+
+TEST(Ex, MessageGame)
+{
+	CNetMsg_Sv_MyOwnMessage Msg;
+	Msg.m_Test = 1234567890;
+	CMsgPacker Packer(NETMSGTYPE_SV_MYOWNMESSAGE);
+	Msg.Pack(&Packer);
+
+	CUnpacker Unpacker;
+	CNetObjHandler Handler;
+	TestMessage(false, NETMSGTYPE_SV_MYOWNMESSAGE, Packer.Data(), Packer.Size(), &Unpacker);
+	CNetMsg_Sv_MyOwnMessage *pMsg = (CNetMsg_Sv_MyOwnMessage *)Handler.SecureUnpackMsg(NETMSGTYPE_SV_MYOWNMESSAGE, &Unpacker);
+	ASSERT_NE(pMsg, nullptr);
+	EXPECT_EQ(pMsg->m_Test, 1234567890);
+}
+
+TEST(Ex, SnapshotObject)
+{
+	CSnapshotBuilder Builder;
+	Builder.Init();
+	CNetObj_MyOwnObject *pObj = (CNetObj_MyOwnObject *)Builder.NewItem(NETOBJTYPE_MYOWNOBJECT, 0, sizeof(*pObj));
+	CNetObj_MyOwnEvent *pEvent = (CNetObj_MyOwnEvent *)Builder.NewItem(NETOBJTYPE_MYOWNEVENT, 1, sizeof(*pEvent));
+	ASSERT_NE(pObj, nullptr);
+	ASSERT_NE(pEvent, nullptr);
+	pObj->m_Test = 1234567890;
+	pEvent->m_Test = 1357924680;
+
+	unsigned char aData[CSnapshot::MAX_SIZE];
+	Builder.Finish(aData);
+	CSnapshot *pSnap = (CSnapshot *)aData;
+
+	pSnap->DebugDump();
+
+	int IndexObj = -1;
+	int IndexEvent = -1;
+	for(int i = 0; i < pSnap->NumItems(); i++)
+	{
+		int Type = pSnap->GetItemType(i);
+		if(Type == NETOBJTYPE_MYOWNOBJECT)
+		{
+			EXPECT_EQ(IndexObj, -1);
+			EXPECT_EQ(((const CNetObj_MyOwnObject *)pSnap->GetItem(i)->Data())->m_Test, 1234567890);
+			IndexObj = i;
+		}
+		else if(Type == NETOBJTYPE_MYOWNEVENT)
+		{
+			EXPECT_EQ(IndexEvent, -1);
+			EXPECT_EQ(((const CNetObj_MyOwnEvent *)pSnap->GetItem(i)->Data())->m_Test, 1357924680);
+			IndexEvent = i;
+		}
+		else
+		{
+			pSnap->InvalidateItem(i);
+		}
+	}
+	EXPECT_NE(IndexObj, -1);
+	EXPECT_NE(IndexEvent, -1);
+
+	EXPECT_EQ(pSnap->GetItemIndex(NETOBJTYPE_MYOWNOBJECT, 0), IndexObj);
+	EXPECT_EQ(pSnap->GetItemIndex(NETOBJTYPE_MYOWNEVENT, 1), IndexEvent);
+}
+
+static void GetWhatIsAnswer(int Uuid, CMsgPacker *pPacker)
+{
+	CMsgPacker Packer(NETMSG_WHATIS, true);
+	g_UuidManager.PackUuid(Uuid, &Packer);
+	CUnpacker Unpacker;
+	Unpacker.Reset(Packer.Data(), Packer.Size());
+	int ID;
+	bool Sys;
+	CUuid TmpUuid;
+	ASSERT_EQ(UnpackMessageID(&ID, &Sys, &TmpUuid, &Unpacker, pPacker), (int)UNPACKMESSAGE_ANSWER);
+	EXPECT_EQ(Sys, true);
+	EXPECT_EQ(ID, (int)NETMSG_WHATIS);
+}
+
+TEST(Ex, WhatIsKnown)
+{
+	CMsgPacker Buffer(0);
+	CUnpacker Unpacker;
+	GetWhatIsAnswer(NETMSG_MYOWNMESSAGE, &Buffer);
+	TestMessage(true, NETMSG_ITIS, Buffer.Data(), Buffer.Size(), &Unpacker);
+	CUuid Uuid;
+	EXPECT_EQ(g_UuidManager.UnpackUuid(&Unpacker, &Uuid), (int)NETMSG_MYOWNMESSAGE);
+	EXPECT_STREQ(Unpacker.GetString(CUnpacker::SANITIZE_CC), "system-message-my-own-message@heinrich5991.de");
+	EXPECT_FALSE(Unpacker.Error());
+}

--- a/src/tools/uuid.cpp
+++ b/src/tools/uuid.cpp
@@ -1,0 +1,14 @@
+#include <engine/shared/uuid_manager.h>
+int main(int argc, char **argv)
+{
+	dbg_logger_stdout();
+	if(argc != 2)
+	{
+		dbg_msg("usage", "uuid <NAME>");
+		return -1;
+	}
+	CUuid Uuid = CalculateUuid(argv[1]);
+	char aBuf[UUID_MAXSTRSIZE];
+	FormatUuid(Uuid, aBuf, sizeof(aBuf));
+	dbg_msg("uuid", "%s", aBuf);
+}


### PR DESCRIPTION
This system can easily be extended by independent authors without
collisions, something the old system with plain increasing integers did
not allow.

Do this by utilizing the previously unused message code `NETMSG_NULL`
which has a value of 0.

This works for engine and game messages, snapshot items and events.